### PR TITLE
Escape pipe character in Filters table

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The following examples explain how filter parameters work. For the examples, ass
 | `firstName=Jennifer`               | Returns all Persons whose first name is 'Jennifer'.                                                     |
 | `firstName:eq=Jennifer`            | Returns all Persons whose first name is 'Jennifer'.                                                     |
 | `children.firstName:like=%rad%`    | Returns all Persons who have at least one child whose first name contains 'rad'.                        |
-| `lastName|movies.name:like=%Gump%` | Returns all Persons whose last name contains 'Gump' or who acted in a movie whose name contains 'Gump'. |
+| `lastName\|movies.name:like=%Gump%` | Returns all Persons whose last name contains 'Gump' or who acted in a movie whose name contains 'Gump'. |
 | `parent.age:lt=60`                 | Returns all persons whose parent's age is less than 60.                                                 |
 | `parent.age:in=20,22,24`           | Returns all persons whose parent's age is 20, 22 or 24.                                                 |
 


### PR DESCRIPTION
Prevent the pipe character from acting as the end of the table cell.

Before:
<img width="491" alt="screen shot 2017-08-01 at 5 24 20 pm" src="https://user-images.githubusercontent.com/3303680/28852485-55541152-76de-11e7-9c0e-94dc89da8a36.png">

After:
<img width="830" alt="screen shot 2017-08-01 at 5 24 30 pm" src="https://user-images.githubusercontent.com/3303680/28852490-597b22d4-76de-11e7-9621-56bda8eb5b38.png">
