### PR TITLE
Update to Objection.js 0.9.x

### DIFF
--- a/lib/FindQueryBuilder.js
+++ b/lib/FindQueryBuilder.js
@@ -401,8 +401,9 @@ FindQueryBuilder.prototype._buildJoins = function (params, builder) {
 
   _.each(params, function (param) {
     _.each(param.propertyRefs, function (ref) {
-      if (ref.relation && utils.isOneToOneRelation(ref.relation)) {
-        relationsToJoin.push(ref.relation);
+      var rel = ref.relation;
+      if (rel && rel.isOneToOne()) {
+        relationsToJoin.push(rel);
       }
     });
   });
@@ -467,11 +468,12 @@ FindQueryBuilder.prototype._buildOrderBy = function (params, builder) {
         dir = 'desc';
       }
 
-      if (propertyRef.relation) {
-        if (!utils.isOneToOneRelation(propertyRef.relation)) {
+      var rel = propertyRef.relation;
+      if (rel) {
+        if (!rel.isOneToOne()) {
           utils.throwError("Can only order by model's own properties and by BelongsToOneRelation relations' properties");
         }
-        var columnNameAlias = propertyRef.relation.name + _.capitalize(propertyRef.propertyName);
+        var columnNameAlias = rel.name + _.capitalize(propertyRef.propertyName);
         builder.select(propertyRef.fullColumnName() + ' as ' + columnNameAlias);
         builder.orderBy(columnNameAlias, dir);
       } else {

--- a/lib/PropertyRef.js
+++ b/lib/PropertyRef.js
@@ -108,7 +108,7 @@ PropertyRef.prototype._parse = function (str, builder) {
  * @returns {string}
  */
 PropertyRef.prototype.fullColumnName = function () {
-  if (this.relation && utils.isOneToOneRelation(this.relation)) {
+  if (this.relation && this.relation.isOneToOne()) {
     var builder = this.modelClass.query();
     // one-to-one relations are joined and the joined table is given an alias.
     // We must refer to the column through that alias.
@@ -133,16 +133,12 @@ PropertyRef.prototype.buildFilter = function (param, builder, boolOp) {
     whereMethod = boolOp + _.upperFirst(whereMethod);
   }
 
-  if (this.relation && !utils.isOneToOneRelation(this.relation)) {
-    var rel = this.relation;
-    var subQuery = rel.relatedModelClass.QueryBuilder.forClass(rel.relatedModelClass);
-    var ownerRefs = rel.ownerCol.map((ownCol => `${rel.ownerModelClass.tableName}.${ownCol}`));
-    rel.findQuery(subQuery, {
-      ownerIds: ownerRefs,
-      isColumnRef: true
+  var rel = this.relation;
+  if (rel && !rel.isOneToOne()) {
+    const subQuery = rel.findQuery(rel.relatedModelClass.query(), {
+      ownerIds: rel.ownerProp.refs(builder)
     });
     subQuery[whereMethod].apply(subQuery, filter.args);
-
     builder.whereExists(subQuery.build().select(1));
   } else {
     builder[whereMethod].apply(builder, filter.args);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,4 @@
 module.exports = {
-  isOneToOneRelation: function (relation) {
-    return relation instanceof relation.ownerModelClass.BelongsToOneRelation;
-  },
-
   throwError: function (message) {
     var error = new Error(message);
     error.statusCode = 400;

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "knex": "^0.13",
     "mocha": "^2",
     "mysql": "^2",
-    "objection": "^0.8.0",
+    "objection": "github:Vincit/objection.js#d93d18e5220a83b9ef40ad3a53728403c77eed8c",
     "pg": "^6",
     "sqlite3": "^3"
   },


### PR DESCRIPTION
Aware that v0.9.0 is not out yet, I saw that there are some simplifications that will also allow Objection.js to trop some legacy code.

This is mainly about removing the need for `isColumnRef` in `relation.findQuery()` in these two places:

https://github.com/Vincit/objection.js/blob/20293ff24dc2a981951b7586eb47220f5acab5d1/lib/relations/manyToMany/ManyToManyRelation.js#L75-L80

https://github.com/Vincit/objection.js/blob/2dc1a8d517af0518403c5ef6193e31e867b0ef4e/lib/relations/Relation.js#L121-L126

@koskimas once this is in place, I am wondering if `relation.findQuery(builder, opt)` shouldn't become `relation.findQuery(builder, ownerIds)` instead, since that's the only option ever used then...