### PR TITLE
fix: fullColumnName, use ownerModelClass tablename

### DIFF
--- a/lib/PropertyRef.js
+++ b/lib/PropertyRef.js
@@ -111,7 +111,7 @@ class PropertyRef {
       // We must refer to the column through that alias.
 
       return (
-        this.relation.relatedModelClass.getTableName() +
+        this.relation.ownerModelClass.getTableName() +
         '_rel_' +
         this.relation.name +
         '.' +


### PR DESCRIPTION
I fixed this method in my last PR, but I found an issue with my last fix.

The last PR had its tests passing because it only tested filters in self-related tables. This fix will fix it for all relations between different tables too.