### PR TITLE
Add multiple sort columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,5 +180,6 @@ In addition to the filter parameters, there is a set of query parameters that ha
 | `eager=[children, parent.movies]` | Which relations to fetch eagerly for the result models. An objection.js relation expression.             |
 | `orderBy=firstName`               | Sort the result by certain property.                                                                     |
 | `orderByDesc=firstName`           | Sort the result by certain property in descending order.                                                 |
+| `orderByAsc=group\|lastName`      | Sort the result by more than one property in ascending order.                                            |
 | `rangeStart=10`                   | The start of the result range (inclusive). The result will be `{total: 12343, results: [ ... ]}`.        |
 | `rangeEnd=50`                     | The end of the result range (inclusive). The result will be `{total: 12343, results: [ ... ]}`.          |

--- a/lib/FindQueryBuilder.js
+++ b/lib/FindQueryBuilder.js
@@ -449,28 +449,28 @@ class FindQueryBuilder {
 
     _.each(params, param => {
       const orderType = param.specialParameter;
-      let dir = 'asc';
 
       if (orderType && orderType.indexOf('orderBy') !== -1) {
-        const propertyRef = param.propertyRefs[0];
-
+        let dir = 'asc';
         if (orderType === 'orderByDesc') {
           dir = 'desc';
         }
 
-        const rel = propertyRef.relation;
-        if (rel) {
-          if (!rel.isOneToOne()) {
-            utils.throwError(
-              "Can only order by model's own properties and by BelongsToOneRelation relations' properties"
-            );
+        _.each(param.propertyRefs, propertyRef => {
+          const rel = propertyRef.relation;
+          if (rel) {
+            if (!rel.isOneToOne()) {
+              utils.throwError(
+                "Can only order by model's own properties and by BelongsToOneRelation relations' properties"
+              );
+            }
+            const columnNameAlias = rel.name + _.capitalize(propertyRef.propertyName);
+            builder.select(propertyRef.fullColumnName() + ' as ' + columnNameAlias);
+            builder.orderBy(columnNameAlias, dir);
+          } else {
+            builder.orderBy(propertyRef.columnName, dir);
           }
-          const columnNameAlias = rel.name + _.capitalize(propertyRef.propertyName);
-          builder.select(propertyRef.fullColumnName() + ' as ' + columnNameAlias);
-          builder.orderBy(columnNameAlias, dir);
-        } else {
-          builder.orderBy(propertyRef.columnName, dir);
-        }
+        });
       }
     });
   }

--- a/lib/QueryParameter.js
+++ b/lib/QueryParameter.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const utils = require('./utils');
 const filters = require('./filters');
 
@@ -68,7 +69,8 @@ class QueryParameter {
   }
 
   _parseOrderBy(value, key, builder) {
-    this.propertyRefs.push(builder._parsePropertyRef(value));
+    let parsedRefs = builder._parsePropertyRefs(value.split('|'));
+    _.each(parsedRefs, parsedRef => this.propertyRefs.push(parsedRef));
   }
 
   _parseFilter(value, key, builder) {

--- a/tests/test.js
+++ b/tests/test.js
@@ -105,7 +105,7 @@ describe('integration tests', () => {
                   'F09'
                 ]);
               });
-          })
+          });
         });
 
         describe('lt', function() {

--- a/tests/test.js
+++ b/tests/test.js
@@ -35,18 +35,22 @@ describe('integration tests', () => {
        *   Each person is an actor in 10 Movies `M00`, `M01`, `M02`, ...
        *     First person has movies 0 - 9, second 10 - 19 etc.
        *
-       * name    | parent  | pets      | movies
-       * --------+---------+-----------+----------
-       * F00 L09 | null    | P00 - P09 | M99 - M90
-       * F01 L08 | F00 L09 | P10 - P19 | M89 - M80
-       * F02 L07 | F01 L08 | P20 - P29 | M79 - M79
-       * F03 L06 | F02 L07 | P30 - P39 | M69 - M60
-       * F04 L05 | F03 L06 | P40 - P49 | M59 - M50
-       * F05 L04 | F04 L05 | P50 - P59 | M49 - M40
-       * F06 L03 | F05 L04 | P60 - P69 | M39 - M30
-       * F07 L02 | F06 L03 | P70 - P79 | M29 - M20
-       * F08 L01 | F07 L02 | P80 - P89 | M19 - M10
-       * F09 L00 | F08 L01 | P90 - P99 | M09 - M00
+       *   Each person is in one of three groups, `0`, `1` or `2`.
+       *     First, second and third persons are in groups `0`, `1` and `2`. Fourth person is in group `0`
+       *     and this pattern repeats.
+       *
+       * name    | parent  | pets      | movies    | group
+       * --------+---------+-----------+-----------+------
+       * F00 L09 | null    | P00 - P09 | M99 - M90 | 0
+       * F01 L08 | F00 L09 | P10 - P19 | M89 - M80 | 1
+       * F02 L07 | F01 L08 | P20 - P29 | M79 - M79 | 2
+       * F03 L06 | F02 L07 | P30 - P39 | M69 - M60 | 0
+       * F04 L05 | F03 L06 | P40 - P49 | M59 - M50 | 1
+       * F05 L04 | F04 L05 | P50 - P59 | M49 - M40 | 2
+       * F06 L03 | F05 L04 | P60 - P69 | M39 - M30 | 0
+       * F07 L02 | F06 L03 | P70 - P79 | M29 - M20 | 1
+       * F08 L01 | F07 L02 | P80 - P89 | M19 - M10 | 2
+       * F09 L00 | F08 L01 | P90 - P99 | M09 - M00 | 0
        */
       before(() => testUtils.insertData(session, { persons: 10, pets: 10, movies: 10 }));
 
@@ -397,6 +401,27 @@ describe('integration tests', () => {
                 expect(_.map(result, 'name')).to.contain('P00')
               })
           })
+
+          it('should order by multiple columns in ascending order', function() {
+            return objectionFind(Person)
+              .build({
+                orderByAsc: 'group|lastName'
+              })
+              .then(function(result) {
+                expect(_.invokeMap(result, 'fullName')).to.eql([
+                  'F09 L00',
+                  'F06 L03',
+                  'F03 L06',
+                  'F00 L09',
+                  'F07 L02',
+                  'F04 L05',
+                  'F01 L08',
+                  'F08 L01',
+                  'F05 L04',
+                  'F02 L07'
+                ]);
+              });
+          });
         });
 
         describe('orderByDesc', function() {
@@ -438,6 +463,27 @@ describe('integration tests', () => {
                 expect(_.map(result, 'name')).to.contain('P00')
               })
           })
+
+          it('should order by multiple columns in descending order', function() {
+            return objectionFind(Person)
+              .build({
+                orderByDesc: 'group|lastName'
+              })
+              .then(function(result) {
+                expect(_.invokeMap(result, 'fullName')).to.eql([
+                  'F02 L07',
+                  'F05 L04',
+                  'F08 L01',
+                  'F01 L08',
+                  'F04 L05',
+                  'F07 L02',
+                  'F00 L09',
+                  'F03 L06',
+                  'F06 L03',
+                  'F09 L00'
+                ]);
+              });
+          });
         });
       });
 

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -44,6 +44,7 @@ module.exports = {
           .index();
         table.string('firstName');
         table.string('lastName');
+        table.integer('group');
       })
       .createTableIfNotExists('Animal', function(table) {
         table
@@ -110,6 +111,7 @@ module.exports = {
         firstName: 'F' + zeroPad(p),
         lastName: 'L' + zeroPad(P - p - 1),
         age: p * 10,
+        group: p % 3,
 
         pets: _.times(A, function(a) {
           const id = p * A + a + 1;
@@ -132,7 +134,7 @@ module.exports = {
       _.map(_.chunk(persons, C), function(personChunk) {
         return session
           .knex('Person')
-          .insert(pick(personChunk, ['id', 'firstName', 'lastName', 'age']));
+          .insert(pick(personChunk, ['id', 'firstName', 'lastName', 'age', 'group']));
       })
     )
       .then(function() {


### PR DESCRIPTION
Add ability to sort on multiple columns. I done this by extending the `orderBy`, `orderByAsc` and `orderByDesc` query parameters.

Multiple columns can be delimited by the `|` character. I chose this character to be consistent with the way you specify multiple columns in the filter parameters.

This was done in a backwards compatible way. All the existing unit tests still pass unmodified.

I have added two new unit tests to test this functionality.

I updated the readme.

In addition to this, I have also fixing a linting error I introduced in my previous merge request. I included this in a separate commit.