### PR TITLE
fixes for Objection 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ In addition to the filter parameters, there is a set of query parameters that ha
 | Special parameter                 | Explanation                                                                                              |
 |-----------------------------------|----------------------------------------------------------------------------------------------------------|
 | `eager=[children, parent.movies]` | Which relations to fetch eagerly for the result models. An objection.js relation expression. That pass to [withGraphFetched](https://vincit.github.io/objection.js/api/query-builder/eager-methods.html#withgraphfetched). |
-| `join=[parent, parent.movies]`    | Which relations to fetch eagerly for the result models. An objection.js relation expression. That pass to [withGraphJoined](https://vincit.github.io/objection.js/api/query-builder/eager-methods.html#withgraphjoined). |
+| `join=[parent, parent.movies]`    | Which relations to join and fetch eagerly for the result models. An objection.js relation expression. That pass to [withGraphJoined](https://vincit.github.io/objection.js/api/query-builder/eager-methods.html#withgraphjoined). |
 | `orderBy=firstName`               | Sort the result by certain property.                                                                     |
 | `orderByDesc=firstName`           | Sort the result by certain property in descending order.                                                 |
 | `rangeStart=10`                   | The start of the result range (inclusive). The result will be `{total: 12343, results: [ ... ]}`.        |

--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ In addition to the filter parameters, there is a set of query parameters that ha
 
 | Special parameter                 | Explanation                                                                                              |
 |-----------------------------------|----------------------------------------------------------------------------------------------------------|
-| `eager=[children, parent.movies]` | Which relations to fetch eagerly for the result models. An objection.js relation expression.             |
+| `eager=[children, parent.movies]` | Which relations to fetch eagerly for the result models. An objection.js relation expression. That pass to [withGraphFetched](https://vincit.github.io/objection.js/api/query-builder/eager-methods.html#withgraphfetched). |
+| `join=[parent, parent.movies]`    | Which relations to fetch eagerly for the result models. An objection.js relation expression. That pass to [withGraphJoined](https://vincit.github.io/objection.js/api/query-builder/eager-methods.html#withgraphjoined). |
 | `orderBy=firstName`               | Sort the result by certain property.                                                                     |
 | `orderByDesc=firstName`           | Sort the result by certain property in descending order.                                                 |
 | `rangeStart=10`                   | The start of the result range (inclusive). The result will be `{total: 12343, results: [ ... ]}`.        |

--- a/lib/FindQueryBuilder.js
+++ b/lib/FindQueryBuilder.js
@@ -8,6 +8,7 @@ const QueryParameter = require('./QueryParameter');
 
 const SPECIAL_PARAMETERS = Object.freeze({
   eager: 'eager',
+  join: 'join',
   rangeEnd: 'rangeEnd',
   rangeStart: 'rangeStart',
   orderBy: 'orderBy',
@@ -78,7 +79,8 @@ const SPECIAL_PARAMETERS = Object.freeze({
  *
  * | Special parameter             | Explanation                                                                                  |
  * |-------------------------------|----------------------------------------------------------------------------------------------|
- * | `eager=[pets, parent.movies]` | Which relations to fetch eagerly for the result models. An objection.js relation expression. |
+ * | `eager=[pets, parent.movies]` | Which relations to fetch eagerly for the result models. An objection.js relation expression. That pass to `withGraphFetched`. |
+ * | `join=[owner]`                | Which relations to fetch eagerly for the result models. An objection.js relation expression. That pass to `withGraphJoined`. |
  * | `orderBy=firstName`           | Sort the result by certain property.                                                         |
  * | `orderByDesc=firstName`       | Sort the result by certain property in descending order.                                     |
  * | `rangeStart=10`               | The start of the result range. The result will be `{total: 12343, results: [ ... ]}`.        |
@@ -338,6 +340,7 @@ class FindQueryBuilder {
     this._buildOrderBy(params, builder);
     this._buildRange(params, builder);
     this._buildEager(params, builder);
+    this._buildJoin(params, builder);
 
     return builder;
   }
@@ -502,8 +505,21 @@ class FindQueryBuilder {
       builder.allowGraph(this._allowEager);
     }
 
-    // TODO: switchable to `withGraphJoined`
     builder.withGraphFetched(eager.value);
+  }
+
+  _buildJoin(params, builder) {
+    let join = _.find(params, { specialParameter: 'join' });
+
+    if (!join) {
+      return;
+    }
+
+    if (this._allowEager) {
+      builder.allowGraph(this._allowEager);
+    }
+
+    builder.withGraphJoined(join.value);
   }
 
   _parsePropertyRefs(refs) {

--- a/lib/FindQueryBuilder.js
+++ b/lib/FindQueryBuilder.js
@@ -499,10 +499,11 @@ class FindQueryBuilder {
     }
 
     if (this._allowEager) {
-      builder.allowEager(this._allowEager);
+      builder.allowGraph(this._allowEager);
     }
 
-    builder.eager(eager.value);
+    // TODO: switchable to `withGraphJoined`
+    builder.withGraphFetched(eager.value);
   }
 
   _parsePropertyRefs(refs) {

--- a/lib/PropertyRef.js
+++ b/lib/PropertyRef.js
@@ -139,12 +139,10 @@ class PropertyRef {
 
     const rel = this.relation;
     if (rel && !rel.isOneToOne()) {
-      const subQuery = rel.findQuery(rel.relatedModelClass.query(), {
-        ownerIds: rel.ownerProp.refs(builder),
-      });
+      const subQuery = rel.ownerModelClass.relatedQuery(rel.name).alias(rel.relatedModelClass.name);
       subQuery[whereMethod].apply(subQuery, filter.args);
 
-      builder.whereExists(subQuery.toKnexQuery().select(1));
+      builder.whereExists(subQuery.select(1));
     } else {
       builder[whereMethod].apply(builder, filter.args);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1087,6 +1087,12 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "db-errors": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/db-errors/-/db-errors-0.2.3.tgz",
+      "integrity": "sha512-OOgqgDuCavHXjYSJoV2yGhv6SeG8nk42aoCSoyXLZUH7VwFG27rxbavU1z+VrZbZjphw5UkDQwUlD21MwZpUng==",
+      "dev": true
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -4221,14 +4227,33 @@
       }
     },
     "objection": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/objection/-/objection-1.6.11.tgz",
-      "integrity": "sha512-/W6iR6+YvFg1U4k5DyX1MrY+xqodDM8AAOU1J0b3HlptsNw8V3uDHjZgTi1cFPPe5+ZeTTMvhIFhNiUP6+nqYQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/objection/-/objection-2.2.1.tgz",
+      "integrity": "sha512-VY/OGLlLpHwIHck9/HC9meSpjE9w2b4ufxDu/igVCowyDajmcU3AwRmaqKQP8MhMCLPZKSj8gqIAQ5m5zpV5YA==",
       "dev": true,
       "requires": {
-        "ajv": "^6.10.0",
-        "bluebird": "^3.5.5",
-        "lodash": "^4.17.11"
+        "ajv": "^6.12.0",
+        "db-errors": "^0.2.3"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        }
       }
     },
     "once": {

--- a/package.json
+++ b/package.json
@@ -66,14 +66,14 @@
     "mocha": "6.2.3",
     "mysql": "^2.18.1",
     "nyc": "^15.0.1",
-    "objection": "^1.6.11",
+    "objection": "^2.0.0",
     "pg": "^7.18.2",
     "prettier": "^2.0.4",
     "sqlite3": "^4.1.1",
     "typescript": "3.8.3"
   },
   "peerDependencies": {
-    "objection": ">=1.6.11 <2.0.0"
+    "objection": ">=2.0.0 <3.0.0"
   },
   "engines": {
     "node": ">=8"

--- a/tests/test.js
+++ b/tests/test.js
@@ -391,9 +391,8 @@ describe('integration tests', () => {
             return objectionFind(Animal)
               .build({
                 orderByAsc: ['owner:parent:lastName'],
-                eager: 'owner.[parent]',
+                join: 'owner.[parent]',
               })
-              .eagerAlgorithm(Model.JoinEagerAlgorithm)
               .then(function (result) {
                 const names = _.map(
                   _.reject(result, (pet) => _.includes(pet.name, 'P0')),


### PR DESCRIPTION
Replace and fixes method call that deprecated from Objection 2.

refs [Objection 2 support · Issue #59 · Vincit/objection-find](https://github.com/Vincit/objection-find/issues/59)
refs [Unclear migration path for findQuery(query, opts) -> findQuery(query, owner) · Issue #1727 · Vincit/objection.js](https://github.com/Vincit/objection.js/issues/1727)