### PR TITLE
Fix aliasing of HasMany and ManyToMany relations

### DIFF
--- a/lib/PropertyRef.js
+++ b/lib/PropertyRef.js
@@ -105,7 +105,13 @@ class PropertyRef {
    * @returns {string}
    */
   fullColumnName() {
-    if (this.relation && this.relation.isOneToOne()) {
+    if (!this.relation){
+      return this.modelClass.tableName + '.' + this.columnName;
+    }
+    else if (!this.relation.isOneToOne()) {
+      return this.modelClass.name + '.' + this.columnName;
+    }
+    else {
       const builder = this.modelClass.query();
       // one-to-one relations are joined and the joined table is given an alias.
       // We must refer to the column through that alias.
@@ -117,8 +123,6 @@ class PropertyRef {
         '.' +
         this.columnName
       );
-    } else {
-      return this.modelClass.name + '.' + this.columnName;
     }
   }
 

--- a/lib/PropertyRef.js
+++ b/lib/PropertyRef.js
@@ -118,7 +118,7 @@ class PropertyRef {
         this.columnName
       );
     } else {
-      return this.modelClass.tableName + '.' + this.columnName;
+      return this.modelClass.name + '.' + this.columnName;
     }
   }
 


### PR DESCRIPTION
`buildFilter()` aliases relations that are not OneToOne, but `fullColumnName()` does not, the result being that filters on fields nested in HasMany or ManyToMany relations fail.

This commit makes the `fullColumnName()` method alias all such relations.

Resolves #80 